### PR TITLE
Allow acl-template to be applied to multi-authorities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ acl-templates-common/target
 alf_data_dev
 integration-tests/target
 target
+*.project
+*.classpath
+/.settings/
+/integration-tests/.settings/

--- a/acl-templates-repo/pom.xml
+++ b/acl-templates-repo/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.conexiam</groupId>
         <artifactId>alfresco-acl-templates</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
     <properties/>
     <dependencies/>

--- a/acl-templates-repo/pom.xml
+++ b/acl-templates-repo/pom.xml
@@ -2,9 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.conexiam</groupId>
     <artifactId>acl-templates-repo</artifactId>
-    <version>1.0.1</version>
     <name>acl-templates-repo Repository AMP project</name>
     <packaging>jar</packaging>
     <description>Manages the lifecycle of the acl-templates-repo Repository AMP (Alfresco Module Package)</description>

--- a/acl-templates-repo/src/main/java/com/conexiam/acl/templates/service/AclTemplateServiceImpl.java
+++ b/acl-templates-repo/src/main/java/com/conexiam/acl/templates/service/AclTemplateServiceImpl.java
@@ -97,7 +97,16 @@ public class AclTemplateServiceImpl implements AclTemplateService {
         permissionService.deletePermissions(nodeRef);
         permissionService.setInheritParentPermissions(nodeRef, template.isInherit());
         for (AclTemplatePermission entry : template.getPermissions()) {
-            permissionService.setPermission(nodeRef, entry.getAuthority(), entry.getPermission(), entry.getAllow());
+        	String authority = entry.getAuthority();
+        	
+        	// a list of comma separated authorities
+        	if (authority.contains(",")) {
+        		for (String s : authority.split(",")) {
+        			permissionService.setPermission(nodeRef, s, entry.getPermission(), entry.getAllow());
+        		}
+        	} else {
+        		permissionService.setPermission(nodeRef, authority, entry.getPermission(), entry.getAllow());
+        	}
         }
     }
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.conexiam</groupId>
     <artifactId>alfresco-acl-templates</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
   </parent>
   <properties/>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.conexiam</groupId>
   <artifactId>alfresco-acl-templates</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2-SNAPSHOT</version>
   <name>Alfresco ACL Templates</name>
   <description>Alfresco ACL Templates</description>
   <packaging>pom</packaging>


### PR DESCRIPTION
Implemented the apply acl-template to multi-authority (comma separated list of authorities) feature.

If the authorityResolver returns a list like "user1,user2", then split the value in independent authorities and apply the same permission for each of them.